### PR TITLE
Refine URLs from env, create "baseUrl"

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -95,9 +95,9 @@ export async function getStaticProps() {
   const manifests = canopyManifests();
 
   // @ts-ignore
-  const { featuredItems, metadata, url } = process.env
+  const { featuredItems, metadata, url, basePath } = process.env
     .CANOPY_CONFIG as any as string[];
-  const { NEXT_PUBLIC_BASE_PATH } = process.env;
+  const baseUrl = basePath ? `${url}${basePath}` : url;
 
   const randomFeaturedItem =
     manifests[Math.floor(Math.random() * manifests.length)];
@@ -107,7 +107,7 @@ export async function getStaticProps() {
 
   const collections = FACETS.map((facet) => {
     const value = getRelatedFacetValue(facet.label);
-    return `${url}${NEXT_PUBLIC_BASE_PATH}/api/facet/${facet.slug}/${value.slug}.json?sort=random`;
+    return `${baseUrl}/api/facet/${facet.slug}/${value.slug}.json?sort=random`;
   });
 
   return {

--- a/pages/works/[slug].tsx
+++ b/pages/works/[slug].tsx
@@ -30,6 +30,9 @@ export default function Work({ manifest, related }: WorkProps) {
 }
 
 export async function getStaticProps({ params }: { params: any }) {
+  const { url, basePath } = process.env;
+  const baseUrl = basePath ? `${url}${basePath}` : url;
+
   const { id, index } = MANIFESTS.find(
     (item) => item.slug === params.slug
   ) as any;
@@ -44,7 +47,7 @@ export async function getStaticProps({ params }: { params: any }) {
     const value = shuffle(
       facet.values.filter((entry) => entry.docs.includes(index))
     );
-    return `/api/facet/${facet.slug}/${value[0]?.slug}.json?sort=random`;
+    return `${baseUrl}/api/facet/${facet.slug}/${value[0]?.slug}.json?sort=random`;
   });
 
   /**

--- a/pages/works/[slug].tsx
+++ b/pages/works/[slug].tsx
@@ -9,6 +9,7 @@ import { Manifest } from "@iiif/presentation-3";
 import { fetch } from "@iiif/vault-helpers/fetch";
 import { shuffle } from "lodash";
 import { buildManifestSEO } from "@/services/seo";
+import { CanopyEnvironment } from "@/types/canopy";
 
 interface WorkProps {
   manifest: Manifest;
@@ -30,7 +31,8 @@ export default function Work({ manifest, related }: WorkProps) {
 }
 
 export async function getStaticProps({ params }: { params: any }) {
-  const { url, basePath } = process.env;
+  const { url, basePath } = process.env
+    ?.CANOPY_CONFIG as unknown as CanopyEnvironment;
   const baseUrl = basePath ? `${url}${basePath}` : url;
 
   const { id, index } = MANIFESTS.find(
@@ -42,7 +44,6 @@ export async function getStaticProps({ params }: { params: any }) {
    * build the seo object
    */
   const seo = await buildManifestSEO(manifest, `/works/${params.slug}`);
-
   const related = FACETS.map((facet) => {
     const value = shuffle(
       facet.values.filter((entry) => entry.docs.includes(index))

--- a/services/build/aggregate.js
+++ b/services/build/aggregate.js
@@ -9,6 +9,8 @@ const { buildFacets } = require("./facets");
 const { getRepresentativeImage } = require("../iiif/image");
 
 module.exports.build = (env) => {
+  const { url, basePath } = env;
+  const baseUrl = basePath ? `${url}${basePath}` : url;
   const canopyDirectory = ".canopy";
   log(`Building Canopy from IIIF Collection...\n`);
   log(`${env.collection}\n\n`, "yellow");
@@ -139,7 +141,7 @@ module.exports.build = (env) => {
             env.metadata,
             canopyMetadata,
             manifests,
-            env.url
+            baseUrl
           );
           fs.writeFile(
             `${canopyDirectory}/facets.json`,

--- a/services/seo.ts
+++ b/services/seo.ts
@@ -5,15 +5,17 @@ import { getLabel } from "./iiif/label";
 import { getRepresentativeImage } from "./iiif/image";
 
 const buildManifestSEO = async (manifest: Manifest, path: string) => {
-  const { url, label } = process.env
+  const { url, label, basePath } = process.env
     ?.CANOPY_CONFIG as unknown as CanopyEnvironment;
+  const baseUrl = basePath ? `${url}${basePath}` : url;
+
   const images = await getRepresentativeImage(manifest);
   const title = getLabel(manifest.label).join(" - ");
 
   return {
     title: `${title} - ${getLabel(label).join(" - ")}`,
     description: getLabel(manifest.summary).join(" - "),
-    canonical: `${url}${path}`,
+    canonical: `${baseUrl}${path}`,
     openGraph: {
       images: images.map((item: any) => {
         return {

--- a/types/canopy.ts
+++ b/types/canopy.ts
@@ -41,6 +41,7 @@ export interface CanopyEnvironment {
   summary: InternationalString;
   theme: { defaultTheme: string; toggleEnabled: boolean };
   url: string;
+  basePath?: string;
 }
 
 export interface CanopyFacetValueShape {


### PR DESCRIPTION
# What does this do?

This adds some wide (maybe dirty) concatenation of env vars to create `baseUrl`. Including this will be useful for canopy-iiif instances available at `http://example.org` as well as `http://example.org/custom-base-path`.

Note: There still may be some areas of the code needing a similar update.

## What type of change is this?

- [x] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

_Please include any extra notes here._
