### PR TITLE
Refine page title and descriptions.

### DIFF
--- a/content/404.mdx
+++ b/content/404.mdx
@@ -1,5 +1,5 @@
 ---
-title: 404 - Page Not Found
+title: Page Not Found
 ---
 
 # Page Not Found

--- a/content/about/example.mdx
+++ b/content/about/example.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Markdown Example"
+description: Demonstration content showing how incorporate Markdown using the MDX library
 navigation: "about"
 referencedManifests:
   - "https://api.dc.library.northwestern.edu/api/v2/works/84aec8c1-42e8-4e2c-a6b2-1c7e3790217f?as=iiif"

--- a/content/about/example.mdx
+++ b/content/about/example.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Markdown Example"
-description: Demonstration content showing how incorporate Markdown using the MDX library
+description: Demonstration content with Markdown and Components using the MDX library
 navigation: "about"
 referencedManifests:
   - "https://api.dc.library.northwestern.edu/api/v2/works/84aec8c1-42e8-4e2c-a6b2-1c7e3790217f?as=iiif"

--- a/content/about/index.mdx
+++ b/content/about/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: About
+description: Canopy 'makes easy' the creation of digital exhibits for libraries, archives, and museums
 navigation: "about"
 ---
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Canopy IIIF
+title: New Project
 showHero: true
 showHighlighted: true
 ---

--- a/src/customTypes/content.ts
+++ b/src/customTypes/content.ts
@@ -15,6 +15,7 @@ export type FrontMatterContentItem = {
   referencedManifests?: string[];
   navigation?: string;
   title?: string;
+  description?: string;
 };
 
 export type FrontMatterPageProps = {

--- a/src/lib/build/config.ts
+++ b/src/lib/build/config.ts
@@ -19,6 +19,21 @@ const getConfig = (path = "./config/canopy.json", isDev = false) => {
   const config = data && JSON.parse(data);
 
   /**
+   * If the user has not specified a collection in `./config/canopy.json`,
+   * we need to set the label and summary to default demonstration values.
+   */
+  if (!config?.collection) {
+    defaultConfig.label = {
+      none: ["Canopy IIIF"],
+    };
+    defaultConfig.summary = {
+      none: [
+        "a IIIF Collection sourced site generator in Next.js for digital collections, humanities, and exhibitions",
+      ],
+    };
+  }
+
+  /**
    * If the user has not specified metadata, but has specified a collection,
    * we need to create an empty array for the metadata.
    */

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -17,7 +17,9 @@ const buildManifestSEO = async (manifest: Manifest, path: string) => {
 
   return {
     title: `${title} - ${getLabel(label).join(" - ")}`,
-    description: getLabel(manifest.summary).join(" - "),
+    ...(manifest.summary && {
+      description: getLabel(manifest.summary).join(" - "),
+    }),
     canonical: `${baseUrl}${path}`,
     openGraph: {
       images: images?.map((item: any) => {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,7 @@
 import { IIIFExternalWebResource, Manifest } from "@iiif/presentation-3";
 
 import { CanopyEnvironment } from "@customTypes/canopy";
+import { FrontMatterContentItem } from "@src/customTypes/content";
 import MANIFESTS from "@.canopy/manifests.json";
 import { getLabel } from "./iiif/label";
 import { getRandomItem } from "./utils";
@@ -32,11 +33,29 @@ const buildManifestSEO = async (manifest: Manifest, path: string) => {
   };
 };
 
+const buildContentSEO = (frontMatter: FrontMatterContentItem, path: string) => {
+  const { url, label, basePath } = process.env
+    ?.CANOPY_CONFIG as unknown as CanopyEnvironment;
+  const baseUrl = basePath ? `${url}${basePath}` : url;
+  const title = frontMatter?.title || "";
+  const description = frontMatter?.description;
+
+  return {
+    title: `${title} - ${getLabel(label).join(" - ")}`,
+    ...(description && { description }),
+    canonical: `${baseUrl}${path}`,
+  };
+};
+
 const buildDefaultSEO = (config: any) => {
   const label = config.label ? config.label : "";
   const summary = config.summary ? config.summary : "";
 
-  const title = getLabel(label).join(" - ");
+  const siteTitle = getLabel(label).join(" - ");
+
+  const title = config.pageTitle
+    ? `${config.pageTitle} - ${siteTitle}`
+    : siteTitle;
   const description = getLabel(summary).join(" - ");
   const featured = config.featured;
 
@@ -65,4 +84,4 @@ const buildDefaultSEO = (config: any) => {
   };
 };
 
-export { buildDefaultSEO, buildManifestSEO };
+export { buildContentSEO, buildDefaultSEO, buildManifestSEO };

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -26,10 +26,13 @@ export async function getStaticProps() {
     directory: "",
   });
 
+  const pageTitle = frontMatter?.title ? frontMatter?.title : "404";
+
   return {
     props: {
       frontMatter,
       source,
+      pageTitle,
     },
   };
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,11 +29,13 @@ export default function CanopyAppProps({
   const label = root?.label;
 
   const { locales, theme } = config;
+
   const seo = pageProps.seo
     ? pageProps.seo
     : buildDefaultSEO({
         ...config,
         label,
+        pageTitle: pageProps?.pageTitle,
       });
 
   const [locale, setLocale] = useState<CanopyLocale>();

--- a/src/pages/about/[slug].tsx
+++ b/src/pages/about/[slug].tsx
@@ -4,6 +4,7 @@ import CanopyMDXRemote from "@src/components/MDX";
 import { FrontMatterPageProps } from "@customTypes/content";
 import { GetStaticPropsContext } from "next";
 import LayoutsBasic from "@src/components/Layouts/Basic";
+import { buildContentSEO } from "@src/lib/seo";
 
 /**
  * Specifies the relative path of the directory containing the Markdown.
@@ -43,11 +44,16 @@ export async function getStaticPaths() {
  * files.
  */
 export async function getStaticProps({ params }: GetStaticPropsContext) {
+  const slug = params?.slug as string;
+  const path = `/${CONTENT_DIRECTORY}/${slug}`;
+  const { frontMatter, source } = await getMarkdownContent({
+    slug,
+    directory: CONTENT_DIRECTORY,
+  });
+  const seo = buildContentSEO(frontMatter, path);
+
   return {
-    props: await getMarkdownContent({
-      slug: (params?.slug as string) || "",
-      directory: CONTENT_DIRECTORY,
-    }),
+    props: { frontMatter, seo, source },
   };
 }
 

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,6 +1,7 @@
 import CanopyMDXRemote from "@src/components/MDX";
 import { FrontMatterPageProps } from "@customTypes/content";
 import LayoutsBasic from "@src/components/Layouts/Basic";
+import { buildContentSEO } from "@src/lib/seo";
 import { getMarkdownContent } from "@lib/contentHelpers";
 
 /**
@@ -29,11 +30,15 @@ const ContentPage = ({ source, frontMatter }: FrontMatterPageProps) => {
  * files.
  */
 export async function getStaticProps() {
+  const path = `/${CONTENT_DIRECTORY}`;
+  const { frontMatter, source } = await getMarkdownContent({
+    slug: "index",
+    directory: CONTENT_DIRECTORY,
+  });
+  const seo = buildContentSEO(frontMatter, path);
+
   return {
-    props: await getMarkdownContent({
-      slug: "index",
-      directory: CONTENT_DIRECTORY,
-    }),
+    props: { frontMatter, seo, source },
   };
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import { LocaleString } from "@hooks/useLocale";
 import { MDXRemoteSource } from "@customTypes/content";
 import React from "react";
 import Related from "../components/Related/Related";
+import { buildContentSEO } from "@src/lib/seo";
 import { canopyManifests } from "@lib/constants/canopy";
 import { createCollection } from "../lib/iiif/constructors/collection";
 import { getMarkdownContent } from "@src/lib/contentHelpers";
@@ -58,6 +59,8 @@ export async function getStaticProps() {
     directory: "",
   });
 
+  const pageTitle = frontMatter?.title ? frontMatter?.title : "Home";
+
   /**
    * Handle presentation logic below, determined by Front Matter config?
    */
@@ -85,6 +88,7 @@ export async function getStaticProps() {
       metadataCollections,
       featuredItems,
       frontMatter,
+      pageTitle,
       source,
     },
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,6 @@ import { LocaleString } from "@hooks/useLocale";
 import { MDXRemoteSource } from "@customTypes/content";
 import React from "react";
 import Related from "../components/Related/Related";
-import { buildContentSEO } from "@src/lib/seo";
 import { canopyManifests } from "@lib/constants/canopy";
 import { createCollection } from "../lib/iiif/constructors/collection";
 import { getMarkdownContent } from "@src/lib/contentHelpers";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,7 +61,7 @@ export async function getStaticProps() {
   const pageTitle = frontMatter?.title ? frontMatter?.title : "Home";
 
   /**
-   * Handle presentation logic below, determined by Front Matter config?
+   * Handle presentation logic below
    */
 
   const manifests = canopyManifests();

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -1,11 +1,13 @@
+// @ts-nocheck
+
 import "leaflet/dist/leaflet.css";
 
 import Layout from "@components/layout";
+import { Manifest } from "@iiif/presentation-3";
 import React from "react";
 import { canopyManifests } from "@lib/constants/canopy";
 import dynamic from "next/dynamic";
 import { getFeatures } from "@lib/iiif/navPlace";
-import { Manifest } from "@iiif/presentation-3";
 
 const Map = dynamic(() => import("../components/Map/Map"), { ssr: false });
 
@@ -27,25 +29,28 @@ export default function MapPage({ manifests }: MapPageProps) {
 }
 
 export async function getStaticProps() {
-  const enabled =  process.env.CANOPY_CONFIG.map.enabled;
+  const enabled = process.env.CANOPY_CONFIG.map.enabled;
 
   if (!enabled) {
     return {
       notFound: true,
-    }
+    };
   }
 
   try {
+    const pageTitle = "Map";
+
     return {
       props: {
         manifests: canopyManifests(),
+        pageTitle,
       },
     };
   } catch (error) {
     console.error("Error fetching data:", error);
 
     return {
-      notFound: true
+      notFound: true,
     };
   }
 }

--- a/src/pages/metadata.tsx
+++ b/src/pages/metadata.tsx
@@ -71,7 +71,9 @@ export default function Metadata() {
 }
 
 export async function getStaticProps() {
+  const pageTitle = "Metadata";
+
   return {
-    props: {},
+    props: { pageTitle },
   };
 }

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -91,4 +91,12 @@ const Search = () => {
   );
 };
 
+export async function getStaticProps() {
+  const pageTitle = "Search";
+
+  return {
+    props: { pageTitle },
+  };
+}
+
 export default Search;


### PR DESCRIPTION
# What does this do?

This refines page titles and descriptions throughout the Canopy project.

- All MDX pages now will have their `<title>` and `og:title` customizable from the `title` key in frontmatter.
- Custom content pages (not home and 404) will use the frontmatter `description` key for their meta tags. Home falls back to the summary on the canopy config, 404 doesn't have one.
- Search, Metadata, and Map routes now have hardcoded titles. This isn't working off a locale but that should be a future consideration.

## What type of change is this?

- [x] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [x] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structure (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

_Please include any extra notes here._
