### PR TITLE
Simplify height of Clover viewer, remove relative container.

### DIFF
--- a/src/components/Work/Viewer.tsx
+++ b/src/components/Work/Viewer.tsx
@@ -1,12 +1,9 @@
-import { Box } from "@radix-ui/themes";
 import { CloverViewerProps } from "@samvera/clover-iiif";
 import Viewer from "@src/components/Viewer/Viewer";
 
 const WorkViewer = (props: CloverViewerProps) => {
   return (
-    <Box height="50vh" position="relative">
-      <Viewer options={{ canvasHeight: "100%" }} {...props} />
-    </Box>
+    <Viewer options={{ canvasHeight: "50vh" }} {...props} />
   );
 };
 


### PR DESCRIPTION
# What does this do?

Fixes long-standing issue with height being jammed up by relative container when canvasHeight of Clover IIIF Viewer is 100% or auto.

Looks like this now:
https://canopy-iiif-git-mathewjordan-patch-1-iiif.vercel.app/works/the-north-american-indian-being-a-series-of-volumes-picturing-and-describing-the-indians-of-the-unit

Previously:
https://canopy-iiif.github.io/canopy-iiif/works/the-north-american-indian-being-a-series-of-volumes-picturing-and-describing-the-indians-of-the-unit