### PR TITLE
Pad ReferencedItems cards.

### DIFF
--- a/src/components/MDX/Card.styled.ts
+++ b/src/components/MDX/Card.styled.ts
@@ -1,6 +1,6 @@
 import {styled} from "@styles/stitches.ts";
 
-const CardStyled = styled("div", {
+const MDXCardStyled = styled("div", {
   paddingBottom: "$gr4",
   zIndex: "1",
 

--- a/src/components/MDX/Card.styled.ts
+++ b/src/components/MDX/Card.styled.ts
@@ -1,0 +1,24 @@
+import {styled} from "@styles/stitches.ts";
+
+const CardStyled = styled("div", {
+  paddingBottom: "$gr4",
+  zIndex: "1",
+
+  "@xxs": {
+    paddingBottom: "$gr2",
+  },
+
+  "@xs": {
+    paddingBottom: "$gr2",
+  },
+
+  "@sm": {
+    paddingBottom: "$gr3",
+  },
+
+  "@md": {
+    paddingBottom: "$gr3",
+  },
+});
+
+export { CardStyled };

--- a/src/components/MDX/Card.styled.ts
+++ b/src/components/MDX/Card.styled.ts
@@ -11,5 +11,6 @@ const MDXCardStyled = styled("div", {
   "@xs": {
     paddingBottom: "$gr2",
   },
+});
 
-export { CardStyled };
+export { MDXCardStyled };

--- a/src/components/MDX/Card.styled.ts
+++ b/src/components/MDX/Card.styled.ts
@@ -4,21 +4,12 @@ const CardStyled = styled("div", {
   paddingBottom: "$gr4",
   zIndex: "1",
 
-  "@xxs": {
-    paddingBottom: "$gr2",
+  "@md": {
+    paddingBottom: "$gr3",
   },
 
   "@xs": {
     paddingBottom: "$gr2",
   },
-
-  "@sm": {
-    paddingBottom: "$gr3",
-  },
-
-  "@md": {
-    paddingBottom: "$gr3",
-  },
-});
 
 export { CardStyled };

--- a/src/components/MDX/Card.tsx
+++ b/src/components/MDX/Card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import Card from "@components/Card/Card";
-import { CardStyled } from "@components/MDX/Card.styled.ts";
+import { MDXCardStyled } from "@components/MDX/Card.styled.ts";
 import { canopyManifests } from "@lib/constants/canopy";
 
 const MDXCard = ({ iiifContent }: { iiifContent: string }) => {

--- a/src/components/MDX/Card.tsx
+++ b/src/components/MDX/Card.tsx
@@ -29,7 +29,7 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
 
   if (!resource) return null;
 
-  return <span><CardStyled><Card resource={resource} /></CardStyled></span>;
+  return <MDXCardStyled><Card resource={resource} /></MDXCardStyled>;
 };
 
 export default MDXCard;

--- a/src/components/MDX/Card.tsx
+++ b/src/components/MDX/Card.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { CanopyEnvironment } from "@customTypes/canopy";
 import Card from "@components/Card/Card";
 import { MDXCardStyled } from "@components/MDX/Card.styled.ts";
 import { canopyManifests } from "@lib/constants/canopy";
@@ -10,7 +11,7 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
 
   useEffect(() => {
     const item = manifests.find((manifest) => manifest.id === iiifContent);
-
+    const { basePath } = (process.env.CANOPY_CONFIG ?? {}) as CanopyEnvironment;
     if (item)
       setResource({
         id: iiifContent,
@@ -19,7 +20,7 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
         thumbnail: item.thumbnail,
         homepage: [
           {
-            id: `/works/${item.slug}`,
+            id: `${basePath}/works/${item.slug}`,
             label: item.label,
             type: "Text",
           },

--- a/src/components/MDX/Card.tsx
+++ b/src/components/MDX/Card.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import Card from "@components/Card/Card";
+import { CardStyled } from "@components/MDX/Card.styled.ts";
 import { canopyManifests } from "@lib/constants/canopy";
 
 const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
@@ -28,7 +29,7 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
 
   if (!resource) return null;
 
-  return <Card resource={resource} />;
+  return <span><CardStyled><Card resource={resource} /></CardStyled></span>;
 };
 
 export default MDXCard;


### PR DESCRIPTION
# What does this do?

This is a tiny change to ensure `MDX.Cards` in `ReferencedItems` have padding and a similar layout to how Masonry Cards are done.

## What type of change is this?

- [x] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

I recognize that there is a want to move away from Stitches, but I wasn't sure the correct pattern to use now.  Happy to talk about this here and do it the new way.  I'm demoing something for donors next week and would love to pull this padding from upstream rather than maintain in my fork regardless of how code needs to look.
