### PR TITLE
Enhance link testing.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,33 +1,107 @@
-name: Test IIIF Collection Build
+name: Test and Build
+
 on: push
+
 jobs:
-  test-build:
+  setup:
     runs-on: ubuntu-latest
-    # Only run if the repository is canopy-iiif/canopy-iiif
+    outputs:
+      cache-hit: ${{ steps.cache-deps.outputs.cache-hit }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Cache Node Modules
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        run: npm install
+
+  test:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Restore Node Modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies (if needed)
+        run: npm install
+
+      - name: Unit Testing
+        run: npm run test:ci
+
+  build:
+    needs: setup
+    runs-on: ubuntu-latest
     if: github.repository == 'canopy-iiif/canopy-iiif'
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Restore Node Modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies (if needed)
         run: npm install
-      - name: Unit testing
-        run: npm run test:ci
+
       - name: 2.x Collection (Aggregation)
         run: npm run prebuild -- --path=./config/.fixtures/canopy.presentation-2.json
+
       - name: 2.x Collection (Build)
         run: npm run test-build
+
       - name: 3.0 Collection (Aggregation)
         run: npm run prebuild -- --path=./config/.fixtures/canopy.presentation-3.json
+
       - name: 3.0 Collection (Build)
         run: npm run test-build
+
       - name: Arabic Language (Aggregation)
         run: npm run prebuild -- --path=./config/.fixtures/canopy.arabic.json
+
       - name: Arabic Language (Build)
         run: npm run test-build
+
       - name: Customize Search (Aggregation)
         run: npm run prebuild -- --path=./config/.fixtures/canopy.customize-search.json
+
       - name: Customize Search (Build)
         run: npm run test-build
+
       - name: Minimal Configuration (Aggregation)
         run: npm run prebuild -- --path=./config/.fixtures/canopy.minimal.json
+
       - name: Minimal Configuration (Build)
         run: npm run test-build

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,9 @@
 import "@testing-library/jest-dom";
 
+import { loadEnvConfig } from "@next/env";
+
+loadEnvConfig(process.cwd());
+
 // IntersectionObserver isn't available in test environment
 const mockIntersectionObserver = jest.fn();
 mockIntersectionObserver.mockReturnValue({

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@iiif/parser": "^1.1.2",
         "@iiif/vault-helpers": "^0.10.0",
+        "@next/env": "^15.0.3",
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-accordion": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.0.1",
@@ -2111,9 +2112,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
-      "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.0.3.tgz",
+      "integrity": "sha512-t9Xy32pjNOvVn2AS+Utt6VmyrshbpfUMhIjFO60gI58deSo/KgLOp31XZ4O+kY/Is8WAGYwA5gR7kOb1eORDBA=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.5.4",
@@ -15812,6 +15813,11 @@
         "next": "*"
       }
     },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.7.tgz",
+      "integrity": "sha512-uVuRqoj28Ys/AI/5gVEgRAISd0KWI0HRjOO1CTpNgmX3ZsHb5mdn14Y59yk0IxizXdo7ZjsI2S7qbWnO+GNBcA=="
+    },
     "node_modules/next-themes": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
@@ -15820,6 +15826,11 @@
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
       }
+    },
+    "node_modules/next/node_modules/@next/env": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
+      "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@iiif/parser": "^1.1.2",
     "@iiif/vault-helpers": "^0.10.0",
+    "@next/env": "^15.0.3",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.0.1",

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,21 +1,15 @@
 import * as AspectRatio from "@radix-ui/react-aspect-ratio";
 
-import {
-  Box,
-  Inset,
-  Link,
-  Card as RadixThemesCard,
-  Text,
-} from "@radix-ui/themes";
+import { Box, Inset, Card as RadixThemesCard, Text } from "@radix-ui/themes";
 import { Content, Placeholder, Wrapper } from "@components/Card/Card.styled";
 import { LazyMotion, MotionConfig, domAnimation, m } from "framer-motion";
 
+import CanopyLink from "../Shared/Link";
 import Figure from "@components/Figure/Figure";
 import { Label } from "@samvera/clover-iiif/primitives";
 import React from "react";
 import { SearchResponseItem } from "@customTypes/search/search";
 import { getLabel } from "@lib/iiif/label";
-import { getRandomItem } from "@lib/utils";
 import { useInView } from "react-intersection-observer";
 
 interface CardProps {
@@ -27,7 +21,7 @@ const Card: React.FC<CardProps> = ({ resource }) => {
 
   const { label, homepage, thumbnail } = resource;
   // @ts-ignore
-  const { width, height } = getRandomItem(thumbnail);
+  const { width, height } = thumbnail[0];
 
   if (width && height) aspectRatio = width / height;
 
@@ -42,8 +36,13 @@ const Card: React.FC<CardProps> = ({ resource }) => {
         variant="classic"
         asChild
       >
-        <Link href={homepage && homepage[0].id ? homepage[0].id : ""}>
-          <Inset clip="padding-box" side="top">
+        <CanopyLink href={homepage && homepage[0].id ? homepage[0].id : ""}>
+          <Inset
+            clip="padding-box"
+            side="top"
+            data-testid="canopy-card-inset"
+            data-resource={thumbnail[0].id}
+          >
             <AspectRatio.Root ratio={aspectRatio}>
               <Placeholder>
                 <MotionConfig transition={{ duration: 1 }}>
@@ -67,7 +66,7 @@ const Card: React.FC<CardProps> = ({ resource }) => {
               <Label label={label} />
             </Content>
           </Text>
-        </Link>
+        </CanopyLink>
       </RadixThemesCard>
     </Wrapper>
   );

--- a/src/components/MDX/Card.test.tsx
+++ b/src/components/MDX/Card.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+
+import MDXCard from "@components/MDX/Card";
+import { expectUrl } from "../Shared/Link.test";
+
+jest.mock("@lib/constants/canopy", () => {
+  return {
+    canopyManifests: jest.fn(() => [
+      {
+        id: "http://example.org/iiif/manifest-1",
+        label: "Manifest 1",
+        thumbnail: [
+          {
+            id: "http://example.org/assets/thumbnail-1.jpg",
+            type: "Image",
+            width: 200,
+            height: 200,
+          },
+        ],
+        slug: "manifest-1",
+      },
+      {
+        id: "http://example.org/iiif/manifest-2",
+        label: "Manifest 2",
+        thumbnail: [
+          {
+            id: "http://example.org/assets/thumbnail-2.jpg",
+            type: "Image",
+            width: 200,
+            height: 200,
+          },
+        ],
+        slug: "manifest-2",
+      },
+    ]),
+  };
+});
+
+describe("MDXCard", () => {
+  it("renders", () => {
+    // mock the import of the canopyManifests function
+    render(<MDXCard iiifContent="http://example.org/iiif/manifest-1" />);
+
+    const mdxCard = screen.getByTestId("mdx-card");
+    expect(mdxCard).toHaveTextContent("Manifest 1");
+
+    const cardAnchor = screen.getByRole("link");
+    expect(cardAnchor).toHaveAttribute("href", "/works/manifest-1");
+    expect(cardAnchor).toHaveAttribute(
+      "data-absolute-url",
+      expectUrl("/works/manifest-1")
+    );
+
+    const cardInset = screen.getByTestId("canopy-card-inset");
+    expect(cardInset).toHaveAttribute(
+      "data-resource",
+      "http://example.org/assets/thumbnail-1.jpg"
+    );
+  });
+});

--- a/src/components/MDX/Card.tsx
+++ b/src/components/MDX/Card.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { CanopyEnvironment } from "@customTypes/canopy";
 import Card from "@components/Card/Card";
 import { MDXCardStyled } from "@components/MDX/Card.styled.ts";
 import { canopyManifests } from "@lib/constants/canopy";
@@ -11,7 +10,7 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
 
   useEffect(() => {
     const item = manifests.find((manifest) => manifest.id === iiifContent);
-    const { basePath } = (process.env.CANOPY_CONFIG ?? {}) as CanopyEnvironment;
+
     if (item)
       setResource({
         id: iiifContent,
@@ -20,7 +19,7 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
         thumbnail: item.thumbnail,
         homepage: [
           {
-            id: `${basePath}/works/${item.slug}`,
+            id: `/works/${item.slug}`,
             label: item.label,
             type: "Text",
           },
@@ -30,7 +29,11 @@ const MDXCard = ({ iiifContent }: { iiifContent: string }) => {
 
   if (!resource) return null;
 
-  return <MDXCardStyled><Card resource={resource} /></MDXCardStyled>;
+  return (
+    <MDXCardStyled data-testid="mdx-card">
+      <Card resource={resource} />
+    </MDXCardStyled>
+  );
 };
 
 export default MDXCard;

--- a/src/components/Shared/Link.test.tsx
+++ b/src/components/Shared/Link.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import CanopyLink from "./Link";
+
+const baseUrl = process.env.NEXT_PUBLIC_URL || "http://example.org";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+export function expectUrl(slug: string) {
+  return new URL(`${basePath}${slug}`, baseUrl).toString();
+}
+
+describe("CanopyLink", () => {
+  it("renders", () => {
+    render(<CanopyLink href="/works/manifest-2">Manifest 2</CanopyLink>);
+
+    const anchor = screen.getByRole("link");
+    expect(anchor).toHaveTextContent("Manifest 2");
+    expect(anchor).toHaveAttribute("href", "/works/manifest-2");
+    expect(anchor).toHaveAttribute(
+      "data-absolute-url",
+      expectUrl("/works/manifest-2")
+    );
+  });
+});

--- a/src/components/Shared/Link.tsx
+++ b/src/components/Shared/Link.tsx
@@ -2,6 +2,9 @@ import Link, { LinkProps } from "next/link";
 
 import { Link as RadixThemesLink } from "@radix-ui/themes";
 
+const baseUrl = process.env.NEXT_PUBLIC_URL || "";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
 interface CanopyLinkProps extends LinkProps {
   children: React.ReactNode;
   className?: string;
@@ -9,9 +12,11 @@ interface CanopyLinkProps extends LinkProps {
 }
 
 const CanopyLink = (props: CanopyLinkProps) => {
+  const url = new URL(`${basePath}${props.href}`, baseUrl);
+
   return (
     <RadixThemesLink asChild>
-      <Link {...props} />
+      <Link {...props} data-absolute-url={url.toString()} />
     </RadixThemesLink>
   );
 };


### PR DESCRIPTION
# What does this do?

This updates testing for Card, MDXCard, and CanopyLink components and refines the GitHub workflow for testing and building of Canopy. Because these `<a>` elements will be rendered through the CanopyLink component, the relative Next.js "slug" is what is the value of the `href`, however the intended absolute URL will be built from the Next env variables and is represented in the `data-absolute-url` attribute on this same anchor element.

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚧 **Maintenance or refinement of codebase structure (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

_Please include any extra notes here._
