### PR TITLE
Add GoogleTagManager support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@iiif/parser": "^1.1.2",
         "@iiif/vault-helpers": "^0.10.0",
         "@next/env": "^15.0.3",
+        "@next/third-parties": "^15.0.4",
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-accordion": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.0.1",
@@ -2258,6 +2259,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.0.4.tgz",
+      "integrity": "sha512-Pa0VWD5zROfJGyVIPXvGVE75fGOBWyIwTzsjCWCQ68KzapRRkEFPhyI0PFMsHXLsLhrqM5bx5wwxe7KP7e5tQw==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-66855b96-20241106 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -18591,6 +18604,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@iiif/parser": "^1.1.2",
     "@iiif/vault-helpers": "^0.10.0",
     "@next/env": "^15.0.3",
+    "@next/third-parties": "^15.0.4",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.0.1",

--- a/src/customTypes/canopy.ts
+++ b/src/customTypes/canopy.ts
@@ -1,3 +1,5 @@
+import { GAParams, GTMParams } from "@next/third-parties/dist/types/google";
+
 import { InternationalString } from "@iiif/presentation-3";
 import { ThemeProps } from "@radix-ui/themes";
 
@@ -29,9 +31,8 @@ export interface CanopyTheme extends ThemeProps {
 }
 
 export interface CanopyVendor {
-  googleTagManager?: {
-    container: string;
-  };
+  googleAnalytics?: GAParams;
+  googleTagManager?: GTMParams;
 }
 
 export interface CanopyEnvironment {

--- a/src/customTypes/canopy.ts
+++ b/src/customTypes/canopy.ts
@@ -28,6 +28,12 @@ export interface CanopyTheme extends ThemeProps {
   toggleEnabled: boolean;
 }
 
+export interface CanopyVendor {
+  googleTagManager?: {
+    container: string;
+  };
+}
+
 export interface CanopyEnvironment {
   collection: string;
   featured: string[];
@@ -48,6 +54,7 @@ export interface CanopyEnvironment {
   theme: CanopyTheme;
   url: string;
   basePath?: string;
+  vendor?: CanopyVendor;
 }
 
 export interface CanopyFacetValueShape {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,13 +2,13 @@ import "@radix-ui/themes/styles.css";
 
 import { CanopyEnvironment, CanopyLocale } from "@customTypes/canopy";
 import { CanopyProvider, defaultState } from "../context/canopy";
+import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import React, { useEffect, useState } from "react";
 import { dm_sans, dm_serif_display } from "@styles/theme/fonts";
 import { getDefaultLang, getLocale } from "@hooks/useLocale";
 
 import { AppProps } from "next/app";
 import COLLECTIONS from "@.canopy/collections.json";
-import { GoogleTagManager } from "@next/third-parties/google";
 import { NextSeo } from "next-seo";
 import { Theme } from "@radix-ui/themes";
 import { ThemeProvider } from "next-themes";
@@ -32,8 +32,6 @@ export default function CanopyAppProps({
   const label = root?.label;
 
   const { locales, theme, vendor } = config;
-
-  const GTM_CONTAINER = vendor?.googleTagManager?.container;
 
   const radixTheme = {
     accentColor: theme.accentColor,
@@ -97,7 +95,12 @@ export default function CanopyAppProps({
           </CanopyProvider>
         )}
       </ThemeProvider>
-      {GTM_CONTAINER && <GoogleTagManager gtmId={GTM_CONTAINER} />}
+      {vendor?.googleAnalytics && (
+        <GoogleAnalytics {...vendor.googleAnalytics} />
+      )}
+      {vendor?.googleTagManager && (
+        <GoogleTagManager {...vendor.googleTagManager} />
+      )}
     </>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { getDefaultLang, getLocale } from "@hooks/useLocale";
 
 import { AppProps } from "next/app";
 import COLLECTIONS from "@.canopy/collections.json";
+import { GoogleTagManager } from "@next/third-parties/google";
 import { NextSeo } from "next-seo";
 import { Theme } from "@radix-ui/themes";
 import { ThemeProvider } from "next-themes";
@@ -30,7 +31,9 @@ export default function CanopyAppProps({
   const root = COLLECTIONS.find((collection) => collection.depth === 0);
   const label = root?.label;
 
-  const { locales, theme } = config;
+  const { locales, theme, vendor } = config;
+
+  const GTM_CONTAINER = vendor?.googleTagManager?.container;
 
   const radixTheme = {
     accentColor: theme.accentColor,
@@ -94,6 +97,7 @@ export default function CanopyAppProps({
           </CanopyProvider>
         )}
       </ThemeProvider>
+      {GTM_CONTAINER && <GoogleTagManager gtmId={GTM_CONTAINER} />}
     </>
   );
 }


### PR DESCRIPTION
# What does this do?

This adds Google Tag Manager support to Canopy. Implementers can now add a container id through the `vendor.googleTagManager.gtmId` property. This is then rendered at the app level through the Next.js `_app.tsx` and will be present on all pages.

```json
{
  "collection": "https://iiif.io/api/cookbook/recipe/0032-collection/collection.json",
  "vendor": {
    "googleTagManager": {
      "gtmId": "GTM-XXXXXXXX"
    }
  }
}
```

Users can also opt for direct Google Analytics support:

```json
{
  "collection": "https://iiif.io/api/cookbook/recipe/0032-collection/collection.json",
  "vendor": {
    "googleAnalytics": {
      "gaId": "G-XXXXXXXXXX"
    }
  }
}
```

## What type of change is this?

- [ ] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [x] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structure (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

_Please include any extra notes here._
