### PR TITLE
Insure Flex knows which field to use as the internal key.

### DIFF
--- a/config/.default/canopy.default.json
+++ b/config/.default/canopy.default.json
@@ -36,6 +36,7 @@
       "tokenize": "strict",
       "bidirectional": false,
       "document": {
+        "id": "id",
         "index": [
           {
             "field": "label",


### PR DESCRIPTION
# What does this do?

When Flex encounters malformed data, search will fail as it can't find the unique key of the document, and indexing breaks when it tries to internally organize things. The precise error is `TypeError: a.split is not a function` inside of `Unhandled Runtime Error TypeError: a.split is not a function`.  If we simply add a default unique field to the default config, this problem doesn't seem to happen on search.

## What type of change is this?

- [x] 🐛 **Bug fix** (non-breaking change addressing an issue)
- [ ] ✨ **New feature or enhancement** (non-breaking change which adds functionality)
- [ ] 🧨 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚧 **Maintenance or refinement of codebase structur**e (ex: dependency updates)
- [ ] 📘 **Documentation update**

## Additional Notes

There are some other things here, but this is the biggest. If you want a collection to test with, here is one:

https://iiif.archive.org/iiif/3/terminal-escape-collection/5/collection.json
