### PR TITLE
feat: add minimal react mdx static site generator and IIIF content generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Canopy Static Site Starter
+
+This project is a minimal static site generator using **React** and **MDX**.
+
+- Write pages in [`pages/`](pages/) as `.mdx` files.
+- Run `npm run build` to compile them into static HTML in `dist/`.
+- Generated pages contain only the markup you author, keeping output sizes small.
+
+This starter replaces the previous Next.js structure in `old.nextjs.structure/`.
+
+## IIIF Collection generation
+
+Use `lib/iiif.js` to create simple HTML pages from a IIIF Collection JSON:
+
+```bash
+node lib/iiif.js example-collection.json
+```
+
+Pages are written to `dist/iiif/`.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,34 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { compile, run } from '@mdx-js/mdx';
+import * as runtime from 'react/jsx-runtime';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pagesDir = path.join(__dirname, 'pages');
+const outDir = path.join(__dirname, 'dist');
+
+async function build() {
+  await fs.mkdir(outDir, { recursive: true });
+  const files = await fs.readdir(pagesDir);
+
+  for (const file of files) {
+    if (!file.endsWith('.mdx')) continue;
+    const inputPath = path.join(pagesDir, file);
+    const mdxContent = await fs.readFile(inputPath, 'utf8');
+    const compiled = await compile(mdxContent, { jsx: true, outputFormat: 'function-body' });
+    const { default: Content } = await run(String(compiled), { ...runtime, React });
+    const body = renderToStaticMarkup(React.createElement(Content));
+    const html = `<!doctype html><html><head><meta charset="utf-8" /></head><body>${body}</body></html>`;
+    const outPath = path.join(outDir, file.replace(/\.mdx$/, '.html'));
+    await fs.writeFile(outPath, html);
+    console.log(`Built ${outPath}`);
+  }
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/example-collection.json
+++ b/example-collection.json
@@ -1,0 +1,16 @@
+{
+  "type": "Collection",
+  "id": "https://example.org/iiif/collection",
+  "items": [
+    {
+      "id": "https://example.org/iiif/manifest/1",
+      "type": "Manifest",
+      "label": {"en": ["Example Manifest 1"]}
+    },
+    {
+      "id": "https://example.org/iiif/manifest/2",
+      "type": "Manifest",
+      "label": {"en": ["Example Manifest 2"]}
+    }
+  ]
+}

--- a/lib/iiif.js
+++ b/lib/iiif.js
@@ -1,0 +1,59 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+export async function generateFromCollection(collection, outDir) {
+  await fs.mkdir(outDir, { recursive: true });
+  const items = collection.items || [];
+  for (const item of items) {
+    const label = getLabel(item.label);
+    const body = renderToStaticMarkup(
+      React.createElement('div', null, React.createElement('h1', null, label))
+    );
+    const html = `<!doctype html><html><head><meta charset="utf-8" /></head><body>${body}</body></html>`;
+    const slug = getSlug(item);
+    await fs.writeFile(path.join(outDir, `${slug}.html`), html);
+    console.log(`Generated ${slug}.html`);
+  }
+}
+
+function getLabel(labelObj) {
+  if (!labelObj) return 'Untitled';
+  const values = labelObj.en || labelObj.none || [];
+  return values[0] || 'Untitled';
+}
+
+function getSlug(item) {
+  if (item.id) {
+    try {
+      const url = new URL(item.id);
+      const parts = url.pathname.split('/').filter(Boolean);
+      return parts.pop();
+    } catch {
+      return item.id;
+    }
+  }
+  return getLabel(item.label).toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+async function loadCollection(source) {
+  if (source.startsWith('http://') || source.startsWith('https://')) {
+    const res = await fetch(source);
+    if (!res.ok) throw new Error(`Failed to fetch collection: ${res.status}`);
+    return res.json();
+  }
+  const raw = await fs.readFile(source, 'utf8');
+  return JSON.parse(raw);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const source = process.argv[2];
+  if (!source) {
+    console.error('Usage: node lib/iiif.js <collection.json> [outDir]');
+    process.exit(1);
+  }
+  const outDir = process.argv[3] || path.join(process.cwd(), 'dist', 'iiif');
+  const collection = await loadCollection(source);
+  await generateFromCollection(collection, outDir);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "canopy-iiif",
+  "version": "1.0.0",
+  "description": "Minimal React + MDX static site generator",
+  "type": "module",
+  "scripts": {
+    "build": "node build.js",
+    "test": "echo \"No tests yet\" && exit 0",
+    "iiif": "node lib/iiif.js"
+  },
+  "dependencies": {
+    "@mdx-js/mdx": "^2.3.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,0 +1,3 @@
+# Welcome
+
+This is a starter page powered by **MDX** and React.


### PR DESCRIPTION
## Summary
- scaffold Node.js project for static HTML generation via React and MDX
- add module and example to build simple HTML pages from a IIIF Collection
- document IIIF usage and expose generator script

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find package '@mdx-js/mdx')*
- `node lib/iiif.js example-collection.json` *(fails: Cannot find package 'react')*
- `npm install` *(fails: 403 Forbidden fetching @mdx-js/mdx)*

------
https://chatgpt.com/codex/tasks/task_b_689654c48440832e92663e643df8ec74