### PR TITLE
Remove post-fetch cache rebuild.

### DIFF
--- a/content/docs/developers/releases/releases.data.mjs
+++ b/content/docs/developers/releases/releases.data.mjs
@@ -1,5 +1,11 @@
 const releases = [
   {
+    "version": "1.6.1",
+    "date": "2026-01-26",
+    "summary": "Remove post-fetch cache rebuild.",
+    "highlights": []
+  },
+  {
     "version": "1.6.0",
     "date": "2026-01-25",
     "summary": "Support direct IIIF Manifest aggregation.",

--- a/content/docs/developers/releases/releases.json
+++ b/content/docs/developers/releases/releases.json
@@ -1,5 +1,11 @@
 [
   {
+    "version": "1.6.1",
+    "date": "2026-01-26",
+    "summary": "Remove post-fetch cache rebuild.",
+    "highlights": []
+  },
+  {
     "version": "1.6.0",
     "date": "2026-01-25",
     "summary": "Support direct IIIF Manifest aggregation.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canopy-iiif/app-root",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "An open-source static site generator designed for fast creation, contextualization, and customization of a discovery-focused digital scholarship and collections website using IIIF APIs.",
   "private": true,
   "main": "app/scripts/canopy-build.mjs",

--- a/packages/app/lib/orchestrator.js
+++ b/packages/app/lib/orchestrator.js
@@ -131,6 +131,15 @@ function attachSignalHandlers() {
 async function orchestrate(options = {}) {
   const argv = options.argv || process.argv.slice(2);
   const env = options.env || process.env;
+  if (
+    argv.includes('--debug-iiif') ||
+    argv.includes('--iiif-debug') ||
+    argv.includes('--debug')
+  ) {
+    if (!env.CANOPY_IIIF_DEBUG) env.CANOPY_IIIF_DEBUG = '1';
+    if (!process.env.CANOPY_IIIF_DEBUG) process.env.CANOPY_IIIF_DEBUG = '1';
+    log('IIIF debug logging enabled');
+  }
 
   process.title = 'canopy-app';
   const mode = getMode(argv, env);

--- a/packages/app/lib/search/search.js
+++ b/packages/app/lib/search/search.js
@@ -460,16 +460,43 @@ async function writeSearchIndex(records) {
     console.warn('Search: index size is large (', Math.round(approxBytes / (1024 * 1024)), 'MB ). Consider narrowing sources.');
   }
   await fsp.writeFile(idxPath, indexJson, 'utf8');
+  try {
+    const { logLine } = require('./log');
+    const approxKb = Math.round(approxBytes / 1024);
+    logLine(
+      `• search-index.json written (${indexRecords.length} records, ${approxKb} KB)`,
+      'blue',
+      { dim: true }
+    );
+  } catch (_) {}
 
   const displayPath = path.join(apiDir, 'search-records.json');
   const displayJson = JSON.stringify(displayRecords);
   const displayBytes = Buffer.byteLength(displayJson, 'utf8');
   await fsp.writeFile(displayPath, displayJson, 'utf8');
+  try {
+    const { logLine } = require('./log');
+    const approxKb = Math.round(displayBytes / 1024);
+    logLine(
+      `• search-records.json written (${displayRecords.length} entries, ${approxKb} KB)`,
+      'blue',
+      { dim: true }
+    );
+  } catch (_) {}
   let annotationsBytes = 0;
   if (annotationRecords.length) {
     const annotationsJson = JSON.stringify(annotationRecords);
     annotationsBytes = Buffer.byteLength(annotationsJson, 'utf8');
     await fsp.writeFile(annotationsPath, annotationsJson, 'utf8');
+    try {
+      const { logLine } = require('./log');
+      const approxKb = Math.round(annotationsBytes / 1024);
+      logLine(
+        `• search-index-annotations.json written (${annotationRecords.length} entries, ${approxKb} KB)`,
+        'blue',
+        { dim: true }
+      );
+    } catch (_) {}
   } else {
     try {
       if (fs.existsSync(annotationsPath)) await fsp.unlink(annotationsPath);

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canopy-iiif/app",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": false,
   "license": "MIT",
   "author": "Mat Jordan <mat@northwestern.edu>",

--- a/tests/unit/iiif/helpers.test.js
+++ b/tests/unit/iiif/helpers.test.js
@@ -1,5 +1,7 @@
 const iiif = require('../../../packages/app/lib/build/iiif');
 
+const { resolveIiifSources } = iiif;
+
 const {
   resolvePositiveInteger,
   formatDurationMs,
@@ -90,6 +92,41 @@ describe('normalizeManifestConfig', () => {
   it('returns an empty list when nothing is configured', () => {
     expect(normalizeManifestConfig(null)).toEqual([]);
     expect(normalizeManifestConfig({})).toEqual([]);
+  });
+});
+
+describe('resolveIiifSources', () => {
+  const originalEnv = process.env.CANOPY_COLLECTION_URI;
+  afterEach(() => {
+    process.env.CANOPY_COLLECTION_URI = originalEnv;
+  });
+
+  it('returns configured collection URIs when present', () => {
+    process.env.CANOPY_COLLECTION_URI = '';
+    const sources = resolveIiifSources({
+      collection: [' https://example.org/a ', 'https://example.org/a'],
+    });
+    expect(sources.collections).toEqual(['https://example.org/a']);
+    expect(sources.manifests).toEqual([]);
+  });
+
+  it('falls back to CANOPY_COLLECTION_URI when config is empty', () => {
+    process.env.CANOPY_COLLECTION_URI = 'https://env.example.org/root ';
+    const sources = resolveIiifSources({});
+    expect(sources.collections).toEqual(['https://env.example.org/root']);
+    expect(sources.manifests).toEqual([]);
+  });
+
+  it('includes standalone manifests when configured', () => {
+    process.env.CANOPY_COLLECTION_URI = '';
+    const sources = resolveIiifSources({
+      manifests: [' https://example.org/manifest/1 ', 'https://example.org/manifest/2'],
+    });
+    expect(sources.collections).toEqual([]);
+    expect(sources.manifests).toEqual([
+      'https://example.org/manifest/1',
+      'https://example.org/manifest/2',
+    ]);
   });
 });
 


### PR DESCRIPTION
## What does this do?

This removes an unnecessary cache rebuild step that was occurring silent after we ran through all IIIF resources in the build. This is no longer needed as Manifests and Collections are fetched as they are received (200) automatically. We do retain a lightweight cleanup at the end.

I've added some transparency in logging so we can see these after post-fetch processes:

```
⏱ Chunk 18/18: processed 5 Manifest(s) in 1.2s
IIIF chunk summary: 175 Manifest(s) in 18.1s (avg chunk 1.0s, 9.7 manifest(s)/s)
✓ Wrote navPlace dataset (0 record(s))
• IIIF records collected: 175
• Cleaned IIIF cache (0 Manifest file(s) removed, 0 Collection file(s) removed)
⏱ Build IIIF Collection content completed in 22.5s
```

This is not the most fun thing to review. The best way way to test is to give it a collection previously hanging after IIIF fetches and see if it runs through it and immediately jumps to next step after IIIF fetching is completed.