### PR TITLE
Change IIIF Manifest URI in ImageStory example

### DIFF
--- a/content/docs/components/image-story.mdx
+++ b/content/docs/components/image-story.mdx
@@ -7,16 +7,16 @@ description: Embed the Storiiies viewer to add guided image tours with annotatio
 
 `<ImageStory>` wraps [Storiiies](https://www.cogapp.com/r-d/storiiies) by [Cogapp](https://www.cogapp.com/), an open-source tool for guiding users through a sequence of annotations on an image. `<ImageStory>` accepts IIIF Manifest URIs with annotations targeting rectangles or points on images, and renders them as a guided tour with built-in navigation and annotation text.
 
-The component is ideal for embedding interactive image stories in content pages, making it easy to highlight visual details and provide contextual narratives in an engaging way.
+The component is ideal for embedding interactive image stories in content pages, making it easy to highlight visual details and provide contextual narratives in an engaging way. The example bellow is an embedded version of https://storiiies.cogapp.com/view/3683j/Embassy-of-Hyderbeck-to-Calcutta-1800.
 
 <ImageStory
-  iiifContent="https://manifest.storiiies-editor.cogapp.com/v3/6c83d"
+  iiifContent="https://manifest.storiiies-editor.cogapp.com/v3/3683j"
   height="900"
 />
 
 ```mdx
 <ImageStory
-  iiifContent="https://manifest.storiiies-editor.cogapp.com/v3/6c83d"
+  iiifContent="https://manifest.storiiies-editor.cogapp.com/v3/3683j"
   height="900"
 />
 ```


### PR DESCRIPTION
Updated the IIIF Manifest URI in the ImageStory component to point to a new example.