### PR TITLE
Make cluster work without maxClusterRadius being set.

### DIFF
--- a/packages/app/ui/src/content/map/Map.jsx
+++ b/packages/app/ui/src/content/map/Map.jsx
@@ -310,7 +310,7 @@ function buildClusterOptions(leaflet, maxClusterRadius) {
   const anchor = CUSTOM_MARKER_RADIUS;
   return {
     chunkedLoading: true,
-    maxClusterRadius: typeof maxClusterRadius === "number" ? maxClusterRadius : undefined,
+    maxClusterRadius: typeof maxClusterRadius === "number" ? maxClusterRadius : 160,
     iconCreateFunction: (cluster) => {
       const count = cluster && typeof cluster.getChildCount === "function"
         ? cluster.getChildCount()


### PR DESCRIPTION
It looks like Leaflet's built-in default of 80px is too tight for the 40×40px thumbnail markers used by Canopy. This causes markers to not visually cluster at typical zoom levels. Setting the default to 160px (4× the marker size) ensures clustering works out of the box without requiring maxClusterRadius to be set explicitly on each `<Map>`. This also shouldn't interfere with anyone who does `cluster={false}`.  